### PR TITLE
Solving Issue - No module named 'config' #3

### DIFF
--- a/lib/tools/capture.py
+++ b/lib/tools/capture.py
@@ -16,7 +16,7 @@ import re
 import cv2
 sys.path.append((os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))+ '/common/'))
 
-from config import ToolsConfig
+from .config import ToolsConfig
 from face import FaceDetection
 
 class ToolsCapture:


### PR DESCRIPTION
Changing the path of config file from absolute to relative. Should work in both versions.