### PR TITLE
Add option to use this just for login notifications

### DIFF
--- a/MMM-Facial-Recognition-OCV3.js
+++ b/MMM-Facial-Recognition-OCV3.js
@@ -30,7 +30,9 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 		//Set of modules which should be shown for every user
 		everyoneClass: "everyone",
 		// Boolean to toggle welcomeMessage
-		welcomeMessage: true
+		welcomeMessage: true,
+		// Only send notifications. For handling login actions in a different module.
+		notificationsOnly: false
 	},
 
 	// Define required translations.
@@ -51,17 +53,19 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 
 		var self = this;
 
-		MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
-			module.hide(1000, function() {
-				Log.log(module.name + ' is hidden.');
-			}, {lockString: self.identifier});
-		});
+		if (!this.config.notificationsOnly) {
+			MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
+				module.hide(1000, function() {
+					Log.log(module.name + ' is hidden.');
+				}, {lockString: self.identifier});
+			});
 
-		MM.getModules().withClass(this.current_user).enumerate(function(module) {
-			module.show(1000, function() {
-				Log.log(module.name + ' is shown.');
-			}, {lockString: self.identifier});
-		});
+			MM.getModules().withClass(this.current_user).enumerate(function(module) {
+				module.show(1000, function() {
+					Log.log(module.name + ' is shown.');
+				}, {lockString: self.identifier});
+			});
+		}
 
 		this.sendNotification("CURRENT_USER", this.current_user);
 	},
@@ -69,17 +73,19 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 
 		var self = this;
 
-		MM.getModules().withClass(this.current_user).enumerate(function(module) {
-			module.hide(1000, function() {
-				Log.log(module.name + ' is hidden.');
-			}, {lockString: self.identifier});
-		});
+		if (!this.config.notificationsOnly) {
+			MM.getModules().withClass(this.current_user).enumerate(function(module) {
+				module.hide(1000, function() {
+					Log.log(module.name + ' is hidden.');
+				}, {lockString: self.identifier});
+			});
 
-		MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
-			module.show(1000, function() {
-				Log.log(module.name + ' is shown.');
-			}, {lockString: self.identifier});
-		});
+			MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
+				module.show(1000, function() {
+					Log.log(module.name + ' is shown.');
+				}, {lockString: self.identifier});
+			});
+		}
 
 		this.sendNotification("CURRENT_USER", "None");
 	},
@@ -100,7 +106,7 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 				this.login_user()
 			}
 
-			if (this.config.welcomeMessage) {
+			if (this.config.welcomeMessage && !this.config.notificationsOnly) {
 				this.sendNotification("SHOW_ALERT", {type: "notification", message: this.translate("message").replace("%person", this.current_user), title: this.translate("title")});
 			}
 		}
@@ -111,7 +117,7 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 	},
 
 	notificationReceived: function(notification, payload, sender) {
-		if (notification === 'DOM_OBJECTS_CREATED') {
+		if (notification === 'DOM_OBJECTS_CREATED' && !this.config.notificationsOnly) {
 			var self = this;
 			MM.getModules().exceptWithClass("default").enumerate(function(module) {
 				module.hide(1000, function() {

--- a/MMM-Facial-Recognition-OCV3.js
+++ b/MMM-Facial-Recognition-OCV3.js
@@ -38,9 +38,9 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 		return {
 			en: "translations/en.json",
 			de: "translations/de.json",
-      			es: "translations/es.json",
-      			zh: "translations/zh.json",
-      			nl: "translations/nl.json",
+			es: "translations/es.json",
+			zh: "translations/zh.json",
+			nl: "translations/nl.json",
 			sv: "translations/sv.json",
 			fr: "translations/fr.json",
 			id: "translations/id.json"
@@ -49,7 +49,7 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 
 	login_user: function () {
 
-    var self = this;
+		var self = this;
 
 		MM.getModules().withClass(this.config.defaultClass).exceptWithClass(this.config.everyoneClass).enumerate(function(module) {
 			module.hide(1000, function() {
@@ -67,7 +67,7 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 	},
 	logout_user: function () {
 
-    var self = this;
+		var self = this;
 
 		MM.getModules().withClass(this.current_user).enumerate(function(module) {
 			module.hide(1000, function() {
@@ -112,7 +112,7 @@ Module.register('MMM-Facial-Recognition-OCV3',{
 
 	notificationReceived: function(notification, payload, sender) {
 		if (notification === 'DOM_OBJECTS_CREATED') {
-      var self = this;
+			var self = this;
 			MM.getModules().exceptWithClass("default").enumerate(function(module) {
 				module.hide(1000, function() {
 					Log.log('Module is hidden.');

--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ To setup the module in MagicMirror², add the following script int the `config.j
         //Set of modules which should be shown for every user
         everyoneClass: "everyone",
         // Boolean to toggle welcomeMessage
-        welcomeMessage: true
+        welcomeMessage: true,
+        // Only send notifications. For handling login actions in a different module.
+        notificationsOnly: false
     }
 }
 ```


### PR DESCRIPTION
I like how this module works, however I'm creating a more complex user management system and i'm using this module just for authentication and I will handle changing the visible modules in a different module.

Therefore I added an option to the config that can make this module just send the `CURRENT_USER` notifications without touching the visible modules.

The default functionality remains the same so this doesn't break any previous installations.